### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,6 +27,7 @@ jobs:
           release-type: node
           package-name: '@lukso/lsp6-signer.js'
           bump-minor-pre-major: true
+          bump-patch-for-minor-pre-major: true
 
       - name: 🔍 Check if version changed
         uses: EndBug/version-check@v1


### PR DESCRIPTION
Set bump-patch-for-minor-pre-major to true in order to test the release package without incrementing the major version before 1.0.0