### PR TITLE
Release version 0.1.0

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,7 +40,6 @@ jobs:
           release-type: node
           package-name: '@lukso/lsp6-signer.js'
           bump-minor-pre-major: true
-          bump-patch-for-minor-pre-major: true
           default-branch: main
 
       - name: 🔍 Check if version changed


### PR DESCRIPTION
LSP6Signer library is operational and its version should not be called under 'development' anymore.

This PR **changes the** **version number** of the library from `0.0.2-development` to `0.1.0`. This change will be automatic when develop is merged to main as a commit message contains Release-As: x.x.x.

It also **changes** **the way** **versioning works** : 
-> bump-minor-pre-major is set to true (meaning breaking changes before 1.0.0 should produce minor bumps)

-> bump-patch-for-minor-pre-major is set to false (default) (meaning feat changes before 1.0.0 should not produce patch bumps instead of minor bumps)